### PR TITLE
🎨 Palette: Enhance Start Menu clear search button UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Icon-Only Buttons and Accessibility
+**Learning:** Using raw text like 'x' for icon-only buttons causes screen readers to announce the letter literally, which provides poor context to users. Missing ARIA labels exacerbate this.
+**Action:** Replace text-based icons with semantic SVGs and ensure `aria-label` attributes are consistently applied to icon-only buttons to clearly describe their action.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,81 @@
+$ vite dev --host
+10:18:09 AM [vite] (client) Forced re-optimization of dependencies
+
+  VITE v7.3.1  ready in 1083 ms
+
+  ➜  Local:   http://localhost:5176/
+  ➜  Network: http://192.168.0.2:5176/
+10:18:47 AM [vite-plugin-svelte] plugins/agent-manager/src/AgentManager.svelte:361:10 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:47 AM [vite-plugin-svelte] plugins/agent-manager/src/AgentManager.svelte:371:10 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:47 AM [vite-plugin-svelte] plugins/agent-manager/src/AgentManager.svelte:386:10 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:47 AM [vite-plugin-svelte] plugins/agent-manager/src/AgentManager.svelte:395:10 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:47 AM [vite-plugin-svelte] plugins/agent-manager/src/AgentManager.svelte:415:10 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:47 AM [vite-plugin-svelte] plugins/ai-chat/src/AIChat.svelte:33:23 This reference only captures the initial value of `windowId`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+10:18:47 AM [vite-plugin-svelte] plugins/blog/src/Blog.svelte:174:12 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:48 AM [vite-plugin-svelte] plugins/calculator/src/Calculator.svelte:590:6 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:48 AM [vite-plugin-svelte] plugins/code-editor/src/CodeEditor.svelte:281:10 `<button>` cannot be a child of `<button>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning
+https://svelte.dev/e/node_invalid_placement_ssr
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:15:27 This reference only captures the initial value of `initialPath`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:733:4 Elements with the 'grid' interactive role must have a tabindex value
+https://svelte.dev/e/a11y_interactive_supports_focus
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:781:16 Avoid using autofocus
+https://svelte.dev/e/a11y_autofocus
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:804:14 Avoid using autofocus
+https://svelte.dev/e/a11y_autofocus
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:832:4 Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type="button">` or `<a>` might be more appropriate
+https://svelte.dev/e/a11y_click_events_have_key_events
+10:18:48 AM [vite-plugin-svelte] plugins/file-browser/src/FileBrowser.svelte:832:4 `<div>` with a click handler must have an ARIA role
+https://svelte.dev/e/a11y_no_static_element_interactions
+10:18:49 AM [vite-plugin-svelte] plugins/image-filter/src/ImageFilter.svelte:786:2 Unused CSS selector ".status.error"
+https://svelte.dev/e/css_unused_selector
+10:18:49 AM [vite-plugin-svelte] plugins/image-filter/src/ImageFilter.svelte:1071:2 Unused CSS selector ".error-message"
+https://svelte.dev/e/css_unused_selector
+10:18:49 AM [vite-plugin-svelte] plugins/image-filter/src/ImageFilter.svelte:1078:2 Unused CSS selector ".error-message p"
+https://svelte.dev/e/css_unused_selector
+10:18:49 AM [vite-plugin-svelte] plugins/image-filter/src/ImageFilter.svelte:1082:2 Unused CSS selector ".error-detail"
+https://svelte.dev/e/css_unused_selector
+10:18:49 AM [vite-plugin-svelte] plugins/notes/src/Notes.svelte:28:6 Avoid declaring classes below the top level scope
+https://svelte.dev/e/perf_avoid_nested_class
+10:18:49 AM [vite-plugin-svelte] plugins/plugin-registry/src/PluginRegistry.svelte:123:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectGallery.svelte:219:10 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectGallery.svelte:230:8 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectGallery.svelte:243:8 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectGallery.svelte:344:10 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectGallery.svelte:355:8 A form label must be associated with a control
+https://svelte.dev/e/a11y_label_has_associated_control
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectCard.svelte:43:10 `<button>` cannot be a descendant of `<button>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning
+https://svelte.dev/e/node_invalid_placement_ssr
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectModal.svelte:52:2 Elements with the 'dialog' interactive role must have a tabindex value
+https://svelte.dev/e/a11y_interactive_supports_focus
+10:18:50 AM [vite-plugin-svelte] plugins/project-gallery/src/ProjectModal.svelte:52:2 Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type="button">` or `<a>` might be more appropriate
+https://svelte.dev/e/a11y_click_events_have_key_events
+10:18:50 AM [vite-plugin-svelte] plugins/system-monitor/src/SystemMonitor.svelte:1565:2 Unused CSS selector ".plugin-badge"
+https://svelte.dev/e/css_unused_selector
+10:18:50 AM [vite-plugin-svelte] plugins/weather/src/Weather.svelte:475:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
+https://svelte.dev/e/a11y_consider_explicit_label
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/Welcome.svelte:162:6 Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
+https://svelte.dev/e/element_invalid_self_closing_tag
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/Welcome.svelte:177:2 Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
+https://svelte.dev/e/element_invalid_self_closing_tag
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/Welcome.svelte:202:10 Self-closing HTML tags for non-void elements are ambiguous — use `<span ...></span>` rather than `<span ... />`
+https://svelte.dev/e/element_invalid_self_closing_tag
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/Welcome.svelte:219:12 Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
+https://svelte.dev/e/element_invalid_self_closing_tag
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/Welcome.svelte:308:12 Self-closing HTML tags for non-void elements are ambiguous — use `<span ...></span>` rather than `<span ... />`
+https://svelte.dev/e/element_invalid_self_closing_tag
+10:18:51 AM [vite-plugin-svelte] plugins/welcome/src/WelcomeStep.svelte:47:4 Using `<slot>` to render parent content is deprecated. Use `{@render ...}` tags instead
+https://svelte.dev/e/slot_element_deprecated

--- a/src/lib/shell/StartMenu.svelte
+++ b/src/lib/shell/StartMenu.svelte
@@ -131,10 +131,13 @@
           />
           {#if searchQuery}
             <button
-              class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-slate-600 text-slate-300 text-xs flex items-center justify-center hover:bg-slate-500 transition-colors"
+              class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-slate-600 text-slate-300 flex items-center justify-center hover:bg-slate-500 transition-colors"
               onclick={() => searchQuery = ''}
+              aria-label="Clear search"
             >
-              x
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
             </button>
           {/if}
         </div>


### PR DESCRIPTION
* 💡 What: Replaced the raw text "x" in the Start Menu search's clear button with a semantic SVG icon and added an `aria-label`.
* 🎯 Why: The previous clear button was just a textual "x" which felt unpolished and lacked screen reader support. Using an SVG aligns better with standard UI patterns, and the `aria-label` ensures visually impaired users know what the button does.
* 📸 Before/After: Visual changes were captured during verification (replaced "x" with a standard `X` SVG icon). 
* ♿ Accessibility: Added `aria-label="Clear search"` to the icon-only button, addressing an accessibility gap for screen readers. Added a learning about this to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [17959882031074233361](https://jules.google.com/task/17959882031074233361) started by @rdtect*