### PR TITLE
docs: add contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+
+## Contributing
+
+See [Plugin Architecture](docs/) for how to build plugins.


### PR DESCRIPTION
Adds a contributing section pointing to plugin architecture docs.